### PR TITLE
Contrast 29278

### DIFF
--- a/src/main/java/com/contrastsecurity/task/TeamServerTaskConfiguration.java
+++ b/src/main/java/com/contrastsecurity/task/TeamServerTaskConfiguration.java
@@ -46,6 +46,7 @@ public class TeamServerTaskConfiguration extends AbstractTaskConfigurator
         config.put("profile_select", params.getString("profile_select"));
         config.put("server_name", params.getString("server_name"));
         config.put("app_name", params.getString("app_name"));
+        config.put("passive", params.getString("passive"));
 
 
         int current = 1;
@@ -69,6 +70,7 @@ public class TeamServerTaskConfiguration extends AbstractTaskConfigurator
         context.put("profile_select", "");
         context.put("server_name", "");
         context.put("app_name", "");
+        context.put("passive", "false");
 
         context.put("thresholds", Arrays.asList(new Threshold(0, "","")));
     }
@@ -83,6 +85,7 @@ public class TeamServerTaskConfiguration extends AbstractTaskConfigurator
         context.put("profile_select", taskDefinition.getConfiguration().get("profile_select"));
         context.put("server_name", taskDefinition.getConfiguration().get("server_name"));
         context.put("app_name", taskDefinition.getConfiguration().get("app_name"));
+        context.put("passive", taskDefinition.getConfiguration().get("passive"));
 
         ArrayList<Threshold> thresholds = new ArrayList<Threshold>();
 
@@ -133,6 +136,7 @@ public class TeamServerTaskConfiguration extends AbstractTaskConfigurator
 
         context.put("server_name", taskDefinition.getConfiguration().get("server_name"));
         context.put("app_name", taskDefinition.getConfiguration().get("app_name"));
+        context.put("passive", taskDefinition.getConfiguration().get("passive"));
         context.put("count", taskDefinition.getConfiguration().get("count_1"));
         context.put("severity_select", taskDefinition.getConfiguration().get("severity_select_1"));
         context.put("type_select", taskDefinition.getConfiguration().get("type_select_1"));

--- a/src/main/java/com/contrastsecurity/task/TeamServerTaskConfiguration.java
+++ b/src/main/java/com/contrastsecurity/task/TeamServerTaskConfiguration.java
@@ -46,7 +46,7 @@ public class TeamServerTaskConfiguration extends AbstractTaskConfigurator
         config.put("profile_select", params.getString("profile_select"));
         config.put("server_name", params.getString("server_name"));
         config.put("app_name", params.getString("app_name"));
-        config.put("passive", params.getString("passive"));
+        config.put("passive", Boolean.toString(params.getBoolean("passive")));
 
 
         int current = 1;
@@ -70,7 +70,6 @@ public class TeamServerTaskConfiguration extends AbstractTaskConfigurator
         context.put("profile_select", "");
         context.put("server_name", "");
         context.put("app_name", "");
-        context.put("passive", "false");
 
         context.put("thresholds", Arrays.asList(new Threshold(0, "","")));
     }
@@ -85,7 +84,7 @@ public class TeamServerTaskConfiguration extends AbstractTaskConfigurator
         context.put("profile_select", taskDefinition.getConfiguration().get("profile_select"));
         context.put("server_name", taskDefinition.getConfiguration().get("server_name"));
         context.put("app_name", taskDefinition.getConfiguration().get("app_name"));
-        context.put("passive", taskDefinition.getConfiguration().get("passive"));
+        context.put("passive", Boolean.valueOf(taskDefinition.getConfiguration().get("passive")));
 
         ArrayList<Threshold> thresholds = new ArrayList<Threshold>();
 
@@ -136,7 +135,7 @@ public class TeamServerTaskConfiguration extends AbstractTaskConfigurator
 
         context.put("server_name", taskDefinition.getConfiguration().get("server_name"));
         context.put("app_name", taskDefinition.getConfiguration().get("app_name"));
-        context.put("passive", taskDefinition.getConfiguration().get("passive"));
+        context.put("passive", Boolean.valueOf(taskDefinition.getConfiguration().get("passive")));
         context.put("count", taskDefinition.getConfiguration().get("count_1"));
         context.put("severity_select", taskDefinition.getConfiguration().get("severity_select_1"));
         context.put("type_select", taskDefinition.getConfiguration().get("type_select_1"));

--- a/src/main/java/com/contrastsecurity/task/VerifyThresholdsTask.java
+++ b/src/main/java/com/contrastsecurity/task/VerifyThresholdsTask.java
@@ -68,6 +68,7 @@ public class VerifyThresholdsTask implements TaskType {
         String profile_name = confmap.get("profile_select");
         String server_name = confmap.get("server_name");
         String app_name = confmap.get("app_name");
+        boolean passive = confmap.getAsBoolean("passive");
 
 
         final String key = DATA_STORAGE_CONTRAST + getReportAccessibleKey(taskContext.getBuildContext().getEntityKey().getKey()) + taskContext.getBuildContext().getBuildNumber();

--- a/src/main/resources/editTeamserverTask.ftl
+++ b/src/main/resources/editTeamserverTask.ftl
@@ -22,10 +22,7 @@
         <input class="text" type="text" name="app_name" required="true" value="${app_name}"></input>
     </div>
 
-    <div class="checkbox">
-        <input id="passive" class="checkbox" type="checkbox" name="passive" value="${passive}"></input>
-        <label for="passive">Passive</label>
-    </div>
+    [@ww.checkbox labelKey="Passive" name="passive" toggle="true"/]
 
     [#assign index = 0]
     <fieldset id = "thresholds">

--- a/src/main/resources/editTeamserverTask.ftl
+++ b/src/main/resources/editTeamserverTask.ftl
@@ -21,6 +21,12 @@
         <label>Application Name</label>
         <input class="text" type="text" name="app_name" required="true" value="${app_name}"></input>
     </div>
+
+    <div class="checkbox">
+        <input id="passive" class="checkbox" type="checkbox" name="passive" value="${passive}"></input>
+        <label for="passive">Passive</label>
+    </div>
+
     [#assign index = 0]
     <fieldset id = "thresholds">
         [#list thresholds as threshold]


### PR DESCRIPTION
Added `passive` option to the task configuration. If it is set to true, traces will not be filtered by `appVersionTags`. The filter will include app id, server id, serverity, and vuln. type. 

![image](https://user-images.githubusercontent.com/18661283/50410091-674f3100-07bc-11e9-850a-fdd0a276284e.png)
