### PR TITLE
tavis build was failing. Changed travis.yml file to have jdk as openj…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: java
 sudo: false # faster builds
 jdk:
-  - oraclejdk8
+  - openjdk8


### PR DESCRIPTION
…dk8. It is a workaround in order to have travis build and install a version of jdk to run instead of updating to a more recent jdk. This fail was due to a recent fix implemented in travis that caused past projects passing to fail with JDK8 running. I found this solution in https://travis-ci.community/t/the-travis-ci-build-could-not-be-completed-due-to-an-error/1345 for more details on the past failure